### PR TITLE
feat: GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: 🐞 Bug report
+description: File a bug/issue to help us improve
+title: "[BUG]"
+labels: [bug, needs-triage]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: input
+    attributes:
+      label: What version of the Terraform exporter are you using?
+      description: What version of the Terraform exporter for SAP BTP are you using?
+      placeholder: 0.1.0-beta1
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: What version of the Terraform CLI are you using?
+      description: What version of the Terraform CLI are you using?
+      placeholder: 1.9.0
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: What type of issue are you facing
+      description: What type of issue are you facing?
+      options:
+        - bug report
+        - documentation issue
+        - regression (a behavior that used to work and stopped in a new version)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Provide a clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: |
+        Describe the steps to reproduce the observed behavior.
+
+      placeholder: |
+        1. Execute the command `btptfexporter --help`
+        2. Execute the command ...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: User's Role Collections
+      description: |
+        List the role collections that are assigned to the user executing the CLI.
+
+        This is especially important if you are facing authorization issues like errors with status code 403.
+      placeholder: |
+        - Global Account Viewer
+        - Subaccount Administrator
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Add screenshots to help explain your problem
+      description: |
+        If applicable, add screenshots to help explain your problem.
+
+        Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context like links or references about the problem here. Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: 💡Feature request
+description: Suggest an idea for this project
+title: "[FEATURE]"
+labels: [enhancement, pending-decision]
+body:
+  - type: dropdown
+    attributes:
+      label: What area do you want to see improved?
+      description: Specify the main area that you want to see improved.
+      options:
+        - CLI commands
+        - documentation
+        - examples
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: area
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: Provide a clear and concise description of what the problem is e.g., I am always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution you would like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives you have considered
+      description: A clear and concise description of any alternative solutions or features you have considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context like links or references about the problem here. Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+## Purpose
+<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
+- ...
+
+## Does this introduce a breaking change?
+<!-- Mark one with an "x". -->
+```
+[ ] Yes
+[ ] No
+```
+
+## Pull Request Type
+
+What kind of change does this Pull Request introduce?
+<!-- Please check the one that applies to this PR using "X". -->
+```
+[ ] Bugfix
+[ ] Feature
+[ ] Refactoring (no functional changes, no api changes)
+[ ] Documentation content changes
+[ ] Other... Please describe:
+```
+
+## How to Test
+
+- Test the code via automated test
+
+```bash
+make test
+```
+
+<!-- Add additional steps if applicable -->
+- Additional test steps
+
+```
+...
+```
+
+## What to Check
+
+Verify that the following are valid:
+
+- Automated tests are executed successfully
+<!-- Add additional conditions if applicable -->
+- ...
+
+## Other Information
+<!-- Add any other helpful information that may be needed here. -->
+
+## Checklist for reviewer
+
+<!-- This checklist needs to completed by the reviewer of the PR -->
+The following organizational tasks must be completed before merging this PR:
+
+- [ ] The PR is assigned to the Project board and a status is set (typically "in review").
+- [ ] The PR has the matching labels assigned to it.
+- [ ] The PR has a milestone assigned to it.
+- [ ] If the PR closes an issue, the issue is referenced.
+- [ ] Possible follow-up issues are created and linked.


### PR DESCRIPTION
Adding templates for:

- Pull requests
- Issues, namely feature requests and bug reports

The templates for issues folow the yml paradigm and can be used once the repository is made public
