### PR TITLE
chore: switch of CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,25 +1,25 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
-    paths-ignore:
-      - '*.md'
-      - '*.md.tmpl'
-      - '*.tf'
-  pull_request:
-    branches: [ "main" ]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    paths-ignore:
-      - '*.md'
-      - '*.md.tmpl'
-      - '*.tf'
-  schedule:
-    - cron: '30 4 * * 0'
+  #push:
+  #  branches: [ "main" ]
+  #  paths-ignore:
+  #    - '*.md'
+  #    - '*.md.tmpl'
+  #    - '*.tf'
+  #pull_request:
+  #  branches: [ "main" ]
+  #  types:
+  #    - opened
+  #    - reopened
+  #    - synchronize
+  #    - ready_for_review
+  #  paths-ignore:
+  #    - '*.md'
+  #    - '*.md.tmpl'
+  #    - '*.tf'
+  #schedule:
+  #  - cron: '30 4 * * 0'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Switch off CodeQL until repository is public to avoid unnecessary errors.
