### PR TITLE
feat: accept yes and no

### DIFF
--- a/pkg/tfutils/tfConfig.go
+++ b/pkg/tfutils/tfConfig.go
@@ -208,10 +208,11 @@ func SetupConfigDir(configFolder string, isMainCmd bool) {
 			choice = "N"
 		}
 
-		if strings.ToUpper(choice) == "N" {
+		// We acccept "Yes" or "No" as entry and take the first letter only
+		if strings.ToUpper(choice[:1]) == "N" {
 			CleanupProviderConfig()
 			os.Exit(0)
-		} else if strings.ToUpper(choice) == "Y" {
+		} else if strings.ToUpper(choice[:1]) == "Y" {
 			fmt.Println(output.ColorStringCyan("existing files will be overwritten"))
 
 			// Configuration folder must be re-created, otherwiese the Terraform commands will fail


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Accept "yes" and "no" as answers when a directory should be overwritten
- closes #128

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

<!-- Add additional steps if applicable -->
- Additional test steps

```
Execute the config generation to a directory that already exsisted and enter YES or No (capitalization does not matter)
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
- "Yes" and "No" get recognized as "Y" and "N" would

## Other Information
<!-- Add any other helpful information that may be needed here. -->

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR is assigned to the Project board and a status is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] The PR has a milestone assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
