### PR TITLE
fix: resources names with dots

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,12 +13,12 @@
       "program": "${workspaceFolder}/main.go",
       "args": "${input:cliArgs}",
       "console": "integratedTerminal",
-      "env": {
-        "BTP_USERNAME": "firstname.lastname@sap.com",
-        "BTP_ENABLE_SSO": "true",
-        "BTP_GLOBALACCOUNT": ""
-      },
-      //"envFile": "${workspaceFolder}/.env"
+      //"env": {
+      //  "BTP_USERNAME": "firstname.lastname@sap.com",
+      //  "BTP_ENABLE_SSO": "true",
+      //  "BTP_GLOBALACCOUNT": ""
+      //},
+      "envFile": "${workspaceFolder}/.env"
     },
   ],
   "inputs": [
@@ -26,7 +26,7 @@
       "id": "cliArgs",
       "type": "promptString",
       "description": "Args for launching btptf CLI. Use --cwd to set the working directory.",
-      "default": "export -s 1234567890"
+      "default": "export-by-json -s cf18dcef-5b15-4638-bd98-73f10c7f4f3a"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,12 +13,12 @@
       "program": "${workspaceFolder}/main.go",
       "args": "${input:cliArgs}",
       "console": "integratedTerminal",
-      //"env": {
-      //  "BTP_USERNAME": "firstname.lastname@sap.com",
-      //  "BTP_ENABLE_SSO": "true",
-      //  "BTP_GLOBALACCOUNT": ""
-      //},
-      "envFile": "${workspaceFolder}/.env"
+      "env": {
+        "BTP_USERNAME": "firstname.lastname@sap.com",
+        "BTP_ENABLE_SSO": "true",
+        "BTP_GLOBALACCOUNT": ""
+      },
+      //"envFile": "${workspaceFolder}/.env"
     },
   ],
   "inputs": [
@@ -26,7 +26,7 @@
       "id": "cliArgs",
       "type": "promptString",
       "description": "Args for launching btptf CLI. Use --cwd to set the working directory.",
-      "default": "export-by-json -s cf18dcef-5b15-4638-bd98-73f10c7f4f3a"
+      "default": "export -s 1234567890"
     }
   ]
 }

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -3,7 +3,8 @@ package output
 import "strings"
 
 func FormatResourceNameGeneric(name string) string {
-	return strings.ToLower(strings.Replace(name, " ", "_", -1))
+	nameNoSpaces := strings.ToLower(strings.Replace(name, " ", "_", -1))
+	return strings.Replace(nameNoSpaces, ".", "_", -1)
 }
 
 func FormatDirEntitlementResourceName(appName string, planName string) string {

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -3,8 +3,12 @@ package output
 import "strings"
 
 func FormatResourceNameGeneric(name string) string {
-	nameNoSpaces := strings.ToLower(strings.Replace(name, " ", "_", -1))
-	return strings.Replace(nameNoSpaces, ".", "_", -1)
+	return strings.ToLower(strings.Replace(name, " ", "_", -1))
+}
+
+func FormatRoleResourceName(name string) string {
+	nameGeneric := FormatResourceNameGeneric(name)
+	return strings.Replace(nameGeneric, ".", "_", -1)
 }
 
 func FormatDirEntitlementResourceName(appName string, planName string) string {

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -8,7 +8,8 @@ func FormatResourceNameGeneric(name string) string {
 
 func FormatRoleResourceName(name string) string {
 	nameGeneric := FormatResourceNameGeneric(name)
-	return strings.Replace(nameGeneric, ".", "_", -1)
+	// We replace a dot with two underscores to avoid conflicts with same role names that already contain a underscore
+	return strings.Replace(nameGeneric, ".", "__", -1)
 }
 
 func FormatDirEntitlementResourceName(appName string, planName string) string {

--- a/pkg/output/format_test.go
+++ b/pkg/output/format_test.go
@@ -17,7 +17,7 @@ func TestFormatResourceNameGeneric(t *testing.T) {
 func TestFormatResourceNameRoleWithDots(t *testing.T) {
 
 	input := "ApiManagement.SelfService.Administrator"
-	expected := "apimanagement_selfservice_administrator"
+	expected := "apimanagement__selfservice__administrator"
 
 	result := FormatRoleResourceName(input)
 
@@ -29,7 +29,7 @@ func TestFormatResourceNameRoleWithDots(t *testing.T) {
 func TestFormatResourceNameRoleMisc(t *testing.T) {
 
 	input := "SomeResource withSpaces.AndDots"
-	expected := "someresource_withspaces_anddots"
+	expected := "someresource_withspaces__anddots"
 
 	result := FormatRoleResourceName(input)
 

--- a/pkg/output/format_test.go
+++ b/pkg/output/format_test.go
@@ -14,24 +14,24 @@ func TestFormatResourceNameGeneric(t *testing.T) {
 	}
 }
 
-func TestFormatResourceNameGenericWithDots(t *testing.T) {
+func TestFormatResourceNameRoleWithDots(t *testing.T) {
 
 	input := "ApiManagement.SelfService.Administrator"
 	expected := "apimanagement_selfservice_administrator"
 
-	result := FormatResourceNameGeneric(input)
+	result := FormatRoleResourceName(input)
 
 	if result != expected {
 		t.Errorf("got %q, wanted %q", result, expected)
 	}
 }
 
-func TestFormatResourceNameGenericMisc(t *testing.T) {
+func TestFormatResourceNameRoleMisc(t *testing.T) {
 
 	input := "SomeResource withSpaces.AndDots"
 	expected := "someresource_withspaces_anddots"
 
-	result := FormatResourceNameGeneric(input)
+	result := FormatRoleResourceName(input)
 
 	if result != expected {
 		t.Errorf("got %q, wanted %q", result, expected)

--- a/pkg/output/format_test.go
+++ b/pkg/output/format_test.go
@@ -14,6 +14,30 @@ func TestFormatResourceNameGeneric(t *testing.T) {
 	}
 }
 
+func TestFormatResourceNameGenericWithDots(t *testing.T) {
+
+	input := "ApiManagement.SelfService.Administrator"
+	expected := "apimanagement_selfservice_administrator"
+
+	result := FormatResourceNameGeneric(input)
+
+	if result != expected {
+		t.Errorf("got %q, wanted %q", result, expected)
+	}
+}
+
+func TestFormatResourceNameGenericMisc(t *testing.T) {
+
+	input := "SomeResource withSpaces.AndDots"
+	expected := "someresource_withspaces_anddots"
+
+	result := FormatResourceNameGeneric(input)
+
+	if result != expected {
+		t.Errorf("got %q, wanted %q", result, expected)
+	}
+}
+
 func TestFormatSubscriptionResourceName(t *testing.T) {
 
 	appName := "feature-flags-dashboard"

--- a/pkg/tfimportprovider/directoryRoleImportProvider.go
+++ b/pkg/tfimportprovider/directoryRoleImportProvider.go
@@ -50,7 +50,7 @@ func createDirectoryRoleImportBlock(data map[string]interface{}, directoryId str
 
 		for x, value := range roles {
 			role := value.(map[string]interface{})
-			resourceName := output.FormatResourceNameGeneric(fmt.Sprintf("%v", role["name"]))
+			resourceName := output.FormatRoleResourceName(fmt.Sprintf("%v", role["name"]))
 			directoryAllRoles = append(directoryAllRoles, resourceName)
 			if slices.Contains(filterValues, resourceName) {
 				importBlock += templateDirectoryRoleImport(x, role, directoryId, resourceDoc)

--- a/pkg/tfimportprovider/subaccountRoleImportProvider.go
+++ b/pkg/tfimportprovider/subaccountRoleImportProvider.go
@@ -50,7 +50,7 @@ func createRoleImportBlock(data map[string]interface{}, subaccountId string, fil
 
 		for x, value := range roles {
 			role := value.(map[string]interface{})
-			resourceName := output.FormatResourceNameGeneric(fmt.Sprintf("%v", role["name"]))
+			resourceName := output.FormatRoleResourceName(fmt.Sprintf("%v", role["name"]))
 			subaccountAllRoles = append(subaccountAllRoles, resourceName)
 			if slices.Contains(filterValues, resourceName) {
 				importBlock += templateRoleImport(x, role, subaccountId, resourceDoc)

--- a/pkg/tfutils/tfImport.go
+++ b/pkg/tfutils/tfImport.go
@@ -358,7 +358,8 @@ func transformDataToStringArray(btpResource string, data map[string]interface{})
 	case SubaccountTrustConfigurationType:
 		transformDataToStringArrayGeneric(data, &stringArr, "values", "origin")
 	case SubaccountRoleType, DirectoryRoleType:
-		transformDataToStringArrayGeneric(data, &stringArr, "values", "name")
+		// Special handling needed due to the different format of the role names
+		transformRoleStringArray(data, &stringArr, "values", "name")
 	case SubaccountRoleCollectionType, DirectoryRoleCollectionType:
 		transformDataToStringArrayGeneric(data, &stringArr, "values", "name")
 	case SubaccountServiceInstanceType:
@@ -493,6 +494,14 @@ func transformDataToStringArrayGeneric(data map[string]interface{}, stringArr *[
 	for _, value := range entities {
 		entity := value.(map[string]interface{})
 		*stringArr = append(*stringArr, output.FormatResourceNameGeneric(fmt.Sprintf("%v", entity[resourceKey])))
+	}
+}
+
+func transformRoleStringArray(data map[string]interface{}, stringArr *[]string, dataSourceListKey string, resourceKey string) {
+	entities := data[dataSourceListKey].([]interface{})
+	for _, value := range entities {
+		entity := value.(map[string]interface{})
+		*stringArr = append(*stringArr, output.FormatRoleResourceName(fmt.Sprintf("%v", entity[resourceKey])))
 	}
 }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This fix provides a more generic replacement of resource names that are used for addresses in the Terraform setup.
- Dots that might be used as delimters are replaced by `_` as it was already the case for spaces
- Closes #189

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR is assigned to the Project board and a status is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] The PR has a milestone assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
