### PR TITLE
chore: update deprecated sonar cloud action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           name: coverage-report
           path: cover.out
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Update deprected GH Action for Sonar Cloud scans

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Internal Setup
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
see https://github.com/SonarSource/sonarcloud-github-action

```
This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.
```

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR is assigned to the Project board and a status is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] The PR has a milestone assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
