### PR TITLE
chore: add default labels based on PR title

### DIFF
--- a/.github/workflows/set-default-values-pr.yml
+++ b/.github/workflows/set-default-values-pr.yml
@@ -53,3 +53,34 @@ jobs:
               issue_number: context.issue.number,
               milestone: milestones.data[0].number
            });
+
+      - name: Set default labels
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: actions/github-script@v7
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        with:
+          script: |
+            const title = process.env.TITLE;
+
+            let defaultLabels = [];
+            if (title.startsWith("feat:")) {
+              defaultLabels.push("enhancement");
+            } else if (title.startsWith("fix:")) {
+              defaultLabels.push("bug");
+            } else if (title.startsWith("docs:")) {
+              defaultLabels.push("documentation");
+            } else if (title.startsWith("test:")) {
+              defaultLabels.push("test setup", "internal", "ignore-for-release");
+            } else if (title.startsWith("refactor:")) {
+              defaultLabels.push("internal", "ignore-for-release", "refactoring");
+            } else {
+              defaultLabels.push("internal", "ignore-for-release");
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: defaultLabels
+            });


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Add default labels based on PR title using conventional commits

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: automation setup
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
See <https://www.conventionalcommits.org/en/v1.0.0/>

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
