### PR TITLE
fix(breaking-change): remove cloudfoundry_users from export

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -6,8 +6,16 @@ The btptf CLI can create import blocks and the corresponding configurations only
 
 You find a list of supported resources for the Terraform Provider for SAP BTP in the corresponding repository on GitHub under the [Overview on importable resources](https://github.com/SAP/terraform-provider-btp/blob/main/guides/IMPORT.md).
 
-### Restrictions for Cloud Foundry
+## Restrictions for Cloud Foundry
+
+The btptf CLI can create import blocks and the corresponding configurations only for resources that support the import functionality of Terraform/OpenTofu. Not all resources available in the Terraform providers support this feature and can hence not be imported. For details please check the [documentation](https://registry.terraform.io/providers/cloudfoundry/cloudfoundry/latest).
 
 In case of resources for Cloud Foundry the btptf CLI focuses on the resources that are available in the Cloud Foundry environment on SAP BTP. It is not intended to be a generic tool for vanilla Cloud Foundry deployments.
 
 You find the details about supported and unsupported Cloud Foundry features on SAP BTP on [help.sap.com](https://help.sap.com/docs/btp/sap-business-technology-platform/cloud-foundry-environment#supported-and-unsupported-cloud-foundry-features).
+
+## Temporal Limitations
+
+There might be some temporal limitations as we rely on the functions and features of the Terraform providers for SAP BTP and Cloud Foundry. These limitations might be removed in an upcoming release of the providers. In this section we list these limitations to avoid confusion and to be transparent what might not yet work with the Terraform Exporter for SAP BTP.
+
+- Export of users for Cloud Foundry: Currently there is a limitations for the resource `cloudfoundry_users` which cannot be exported for a Cloud Foundry environment on SAP BTP. This is also documented in the [issue 298](https://github.com/SAP/terraform-exporter-btp/issues/298). A fix is planned for the Terraform provider for Cloud Foundry. After the availability of the fix we can update the Terraform Exporter for SAP BTP and support this resource.

--- a/pkg/tfutils/tfConfig.go
+++ b/pkg/tfutils/tfConfig.go
@@ -41,7 +41,7 @@ var AllowedResourcesDirectory = []string{
 
 var AllowedResourcesOrganization = []string{
 	CmdCfSpaceParameter,
-	CmdCfUserParameter,
+	//CmdCfUserParameter, See https://github.com/SAP/terraform-exporter-btp/issues/298
 	CmdCfDomainParamater,
 	CmdCfOrgRoleParameter,
 	CmdCfRouteParameter,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- As described in #298 the import fails due to authentication issues in the Teraform Provider, to avoid confusion we remove the export of the resource `cloudfoundry_users`
- The resource will be added once the authentication issue is fixed

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Temporal removal of functionality
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
See also: https://github.com/cloudfoundry/terraform-provider-cloudfoundry/issues/143

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
