### PR TITLE
docs: refinement of inline documentationa and docs

### DIFF
--- a/cmd/createJson.go
+++ b/cmd/createJson.go
@@ -19,7 +19,7 @@ var createJsonCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		subaccount, _ := cmd.Flags().GetString("subaccount")
 		directory, _ := cmd.Flags().GetString("directory")
-		organization, _ := cmd.Flags().GetString("organization")
+		organization, _ := cmd.Flags().GetString("org")
 		path, _ := cmd.Flags().GetString("path")
 		resources, _ := cmd.Flags().GetString("resources")
 		space := ""
@@ -65,10 +65,10 @@ func init() {
 
 	createJsonCmd.Flags().StringVarP(&subaccount, "subaccount", "s", "", "ID of the subaccount")
 	createJsonCmd.Flags().StringVarP(&directory, "directory", "d", "", "ID of the directory")
-	createJsonCmd.Flags().StringVarP(&organization, "organization", "o", "", "ID of the Cloud Foundry organization")
+	createJsonCmd.Flags().StringVarP(&organization, "org", "o", "", "ID of the Cloud Foundry org")
 
-	createJsonCmd.MarkFlagsOneRequired("subaccount", "directory", "organization")
-	createJsonCmd.MarkFlagsMutuallyExclusive("subaccount", "directory", "organization")
+	createJsonCmd.MarkFlagsOneRequired("subaccount", "directory", "org")
+	createJsonCmd.MarkFlagsMutuallyExclusive("subaccount", "directory", "org")
 	createJsonCmd.Flags().StringVarP(&path, "path", "p", jsonFileDefault, "Full path to JSON file with list of resources")
 	createJsonCmd.Flags().StringVarP(&resources, "resources", "r", "all", "Comma-separated list of resources to be included")
 
@@ -107,7 +107,7 @@ func getCreateJsonCmdDescription(c *cobra.Command) string {
 		}
 	}
 
-	mainText := `Use this command to create a JSON file that lists all the resources for a directory, subaccount, or environment instance. This lets you easily edit the resources in the file before you export them.
+	mainText := `Use this command to create a JSON file that lists all the resources for a directory, subaccount, or Cloud Foundry org. This lets you easily edit the resources in the file before you export them.
 
 Depending on the account level you specify, the JSON file will include the following resources:`
 
@@ -120,13 +120,13 @@ Depending on the account level you specify, the JSON file will include the follo
 				fmt.Sprint("For subaccounts: " + resources),
 			),
 			formatHelpNote(
-				"For environment instances: " + resourcesEnv,
+				"For Cloud Foundry orgs: " + resourcesEnv,
 			),
 		})
 }
 
 func getCreateJsonUsageNote(c *cobra.Command) string {
-	return getSectionWithHeader("Note", "You must specify one of --subaccount, --directory, or --environment-instance.")
+	return getSectionWithHeader("Note", "You must specify one of --subaccount, --directory, or --org.")
 }
 
 func getCreateJsonCmdExamples(c *cobra.Command) string {
@@ -152,17 +152,17 @@ func getCreateJsonCmdExamples(c *cobra.Command) string {
 			output.ColorStringCyan("--subaccount"),
 			output.ColorStringYellow("<subaccount ID>"),
 		),
-		"Create a JSON file for the spaces of a Cloud Foundry organization": fmt.Sprintf("%s%s %s %s",
+		"Create a JSON file for the spaces of a Cloud Foundry org": fmt.Sprintf("%s%s %s %s",
 			output.ColorStringCyan("btptf create-json --resources="),
 			output.ColorStringYellow("'spaces'"),
-			output.ColorStringCyan("--organization"),
-			output.ColorStringYellow("<organization ID>"),
+			output.ColorStringCyan("--org"),
+			output.ColorStringYellow("<CF org ID>"),
 		),
-		"Create a JSON file for the users of a Cloud Foundry organization": fmt.Sprintf("%s%s %s %s",
+		"Create a JSON file for the users of a Cloud Foundry org": fmt.Sprintf("%s%s %s %s",
 			output.ColorStringCyan("btptf create-json --resources="),
 			output.ColorStringYellow("'users'"),
-			output.ColorStringCyan("--organization"),
-			output.ColorStringYellow("<organization ID>"),
+			output.ColorStringCyan("--org"),
+			output.ColorStringYellow("<CF org ID>"),
 		),
 	})
 }

--- a/cmd/exportByJson.go
+++ b/cmd/exportByJson.go
@@ -20,7 +20,7 @@ var exportByJsonCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		subaccount, _ := cmd.Flags().GetString("subaccount")
 		directory, _ := cmd.Flags().GetString("directory")
-		organization, _ := cmd.Flags().GetString("organization")
+		organization, _ := cmd.Flags().GetString("org")
 		configDir, _ := cmd.Flags().GetString("config-dir")
 		path, _ := cmd.Flags().GetString("path")
 
@@ -80,9 +80,9 @@ func init() {
 
 	exportByJsonCmd.Flags().StringVarP(&subaccount, "subaccount", "s", "", "ID of the subaccount")
 	exportByJsonCmd.Flags().StringVarP(&directory, "directory", "d", "", "ID of the directory")
-	exportByJsonCmd.Flags().StringVarP(&organization, "organization", "o", "", "ID of the Cloud Foundry organization")
-	exportByJsonCmd.MarkFlagsOneRequired("subaccount", "directory", "organization")
-	exportByJsonCmd.MarkFlagsMutuallyExclusive("subaccount", "directory", "organization")
+	exportByJsonCmd.Flags().StringVarP(&organization, "org", "o", "", "ID of the Cloud Foundry org")
+	exportByJsonCmd.MarkFlagsOneRequired("subaccount", "directory", "org")
+	exportByJsonCmd.MarkFlagsMutuallyExclusive("subaccount", "directory", "org")
 
 	exportByJsonCmd.Flags().StringVarP(&configDir, "config-dir", "c", configDirDefault, "Directory for the Terraform code")
 	exportByJsonCmd.Flags().StringVarP(&path, "path", "p", jsonFileDefault, "Full path to JSON file with list of resources")
@@ -101,12 +101,17 @@ func init() {
 
 func getExportByJsonCmdDescription(c *cobra.Command) string {
 
-	mainText := `Use this command to export resources from SAP BTP using a JSON file. The export is always per subaccount, directory, or environment instance. Create the JSON file with 'btptf create-json' and edit it as needed before exporting.`
+	mainText := `Use this command to export resources from SAP BTP using a JSON file. The export is always per subaccount, directory, or Cloud Foundry org. Create the JSON file with 'btptf create-json' and edit it as needed before exporting.`
 	return generateCmdHelpDescription(mainText, nil)
 }
 
 func getExportByJsonCmdDescriptionNote(c *cobra.Command) string {
-	return getSectionWithHeader("Note", "You must specify one of --subaccount, --directory, or --environment-instance.")
+	point1 := formatHelpNote("You must specify one of --subaccount, --directory, or --org.")
+	point2 := formatHelpNote("If you already have a remote state backend for SAP BTP resources which you want to use, specify the remote backend by providing the `--backend-path` or `--backend-type` and `--backend-config`.")
+
+	content := fmt.Sprintf("%s\n%s", point1, point2)
+
+	return getSectionWithHeader("Note", content)
 }
 
 func getExportByJsonCmdExamples(c *cobra.Command) string {
@@ -131,7 +136,7 @@ func getExportByJsonCmdExamples(c *cobra.Command) string {
 			output.ColorStringCyan("--path"),
 			output.ColorStringYellow("'"+filePathSubaccount+"'"),
 		),
-		"Export the resources of a subaccount with a sample backend configuration file": fmt.Sprintf("%s %s",
+		"Export the resources of a subaccount that are listed in the JSON file from the default directory": fmt.Sprintf("%s %s",
 			output.ColorStringCyan("btptf export-by-json --subaccount"),
 			output.ColorStringYellow("<subaccount ID>"),
 		),
@@ -151,9 +156,9 @@ func getExportByJsonCmdExamples(c *cobra.Command) string {
 			output.ColorStringCyan("--backend-config"),
 			output.ColorStringYellow("'storage_account_name=terraformstatestorage'"),
 		),
-		"Export the resources of a Cloud Foundry organization that are listed in the JSON file from the default directory": fmt.Sprintf("%s %s",
-			output.ColorStringCyan("btptf export-by-json --organization"),
-			output.ColorStringYellow("<organization ID>"),
+		"Export the resources of a Cloud Foundry org that are listed in the JSON file from the default directory": fmt.Sprintf("%s %s",
+			output.ColorStringCyan("btptf export-by-json --org"),
+			output.ColorStringYellow("<CF org ID>"),
 		),
 	})
 }

--- a/cmd/exportByResource.go
+++ b/cmd/exportByResource.go
@@ -23,7 +23,7 @@ var exportByResourceCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		subaccount, _ := cmd.Flags().GetString("subaccount")
 		directory, _ := cmd.Flags().GetString("directory")
-		organization, _ := cmd.Flags().GetString("organization")
+		organization, _ := cmd.Flags().GetString("org")
 		configDir, _ := cmd.Flags().GetString("config-dir")
 		resources, _ := cmd.Flags().GetString("resources")
 
@@ -131,9 +131,9 @@ func init() {
 
 	exportByResourceCmd.Flags().StringVarP(&subaccount, "subaccount", "s", "", "ID of the subaccount")
 	exportByResourceCmd.Flags().StringVarP(&directory, "directory", "d", "", "ID of the directory")
-	exportByResourceCmd.Flags().StringVarP(&organization, "organization", "o", "", "ID of the Cloud Foundry organization")
-	exportByResourceCmd.MarkFlagsOneRequired("subaccount", "directory", "organization")
-	exportByResourceCmd.MarkFlagsMutuallyExclusive("subaccount", "directory", "organization")
+	exportByResourceCmd.Flags().StringVarP(&organization, "org", "o", "", "ID of the Cloud Foundry org")
+	exportByResourceCmd.MarkFlagsOneRequired("subaccount", "directory", "org")
+	exportByResourceCmd.MarkFlagsMutuallyExclusive("subaccount", "directory", "org")
 
 	exportByResourceCmd.Flags().StringVarP(&configDir, "config-dir", "c", configDirDefault, "Directory for the Terraform code")
 	exportByResourceCmd.Flags().StringVarP(&resources, "resources", "r", "all", "Comma-separated list of resources to be included")
@@ -179,7 +179,7 @@ func getExportByResourceCmdDescription(c *cobra.Command) string {
 		}
 	}
 
-	mainText := `Use this command to export resources from SAP BTP per account level (subaccount, directory, or environment instance). The command will create a directory with the Terraform configuration files and import blocks for the following resources in your specified account level:`
+	mainText := `Use this command to export resources from SAP BTP per account level (subaccount, directory, or Cloud Foundry org). The command will create a directory with the Terraform configuration files and import blocks for the following resources in your specified account level:`
 	return generateCmdHelpDescription(mainText,
 		[]string{
 			formatHelpNote(
@@ -189,16 +189,17 @@ func getExportByResourceCmdDescription(c *cobra.Command) string {
 				fmt.Sprint("For subaccounts: " + resources),
 			),
 			formatHelpNote(
-				"For environment instances: " + resourcesEnv,
+				"For Cloud Foundry orgs: " + resourcesEnv,
 			),
 		})
 }
 
 func getExportCmdDescriptionNote(c *cobra.Command) string {
 	point1 := formatHelpNote("We recommend to run this command only if you’re familiar with the Terraform resources in your SAP BTP accounts. For a safer approach, use 'btptf export-by-json'.")
-	point2 := formatHelpNote("You must specify one of --subaccount, --directory, or --environment-instance.")
+	point2 := formatHelpNote("You must specify one of --subaccount, --directory, or --org.")
+	point3 := formatHelpNote("If you already have a remote state backend for SAP BTP resources which you want to use, specify the remote backend by providing the `--backend-path` or `--backend-type` and `--backend-config`.")
 
-	content := fmt.Sprintf("%s\n%s", point1, point2)
+	content := fmt.Sprintf("%s\n%s\n%s", point1, point2, point3)
 
 	return getSectionWithHeader("Note", content)
 }
@@ -256,15 +257,15 @@ func getExportByResourceCmdExamples(c *cobra.Command) string {
 			output.ColorStringCyan("--backend-config"),
 			output.ColorStringYellow("'storage_account_name=terraformstatestorage'"),
 		),
-		"Export the spaces of a Cloud Foundry organization": fmt.Sprintf("%s %s %s %s",
-			output.ColorStringCyan("btptf export --organization"),
-			output.ColorStringYellow("<organization ID>"),
+		"Export the spaces of a Cloud Foundry org": fmt.Sprintf("%s %s %s %s",
+			output.ColorStringCyan("btptf export --org"),
+			output.ColorStringYellow("<CF org ID>"),
 			output.ColorStringCyan("--resources"),
 			output.ColorStringYellow("'spaces'"),
 		),
-		"Export the users of a Cloud Foundry organization": fmt.Sprintf("%s %s %s %s",
-			output.ColorStringCyan("btptf export --organization"),
-			output.ColorStringYellow("<organization ID>"),
+		"Export the users of a Cloud Foundry org": fmt.Sprintf("%s %s %s %s",
+			output.ColorStringCyan("btptf export --org"),
+			output.ColorStringYellow("<CF org ID>"),
 			output.ColorStringCyan("--resources"),
 			output.ColorStringYellow("'users'"),
 		),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,7 @@ func getRootCmdDescription(c *cobra.Command) string {
 
 	point1 := formatHelpNote("Directories")
 	point2 := formatHelpNote("Subaccounts")
-	point3 := formatHelpNote("Cloud Foundry environment instances")
+	point3 := formatHelpNote("Cloud Foundry orgs")
 
 	list := fmt.Sprintf("%s\n%s\n%s", point1, point2, point3)
 

--- a/docs/btptf.md
+++ b/docs/btptf.md
@@ -32,12 +32,12 @@ btptf create-json [flags]
 ### Options
 
 ```azdeveloper
-  -d, --directory string      ID of the directory
-  -h, --help                  help for create-json
-  -o, --organization string   ID of the Cloud Foundry organization
-  -p, --path string           Full path to JSON file with list of resources (default "btpResources_<account-id>.json")
-  -r, --resources string      Comma-separated list of resources to be included (default "all")
-  -s, --subaccount string     ID of the subaccount
+  -d, --directory string    ID of the directory
+  -h, --help                help for create-json
+  -o, --org string          ID of the Cloud Foundry org
+  -p, --path string         Full path to JSON file with list of resources (default "btpResources_<account-id>.json")
+  -r, --resources string    Comma-separated list of resources to be included (default "all")
+  -s, --subaccount string   ID of the subaccount
 ```
 
 ### Options inherited from parent commands
@@ -67,7 +67,7 @@ btptf export [flags]
   -c, --config-dir string        Directory for the Terraform code (default "generated_configurations_<account-id>")
   -d, --directory string         ID of the directory
   -h, --help                     help for export
-  -o, --organization string      ID of the Cloud Foundry organization
+  -o, --org string               ID of the Cloud Foundry org
   -r, --resources string         Comma-separated list of resources to be included (default "all")
   -s, --subaccount string        ID of the subaccount
 ```
@@ -99,7 +99,7 @@ btptf export-by-json [flags]
   -c, --config-dir string        Directory for the Terraform code (default "generated_configurations_<account-id>")
   -d, --directory string         ID of the directory
   -h, --help                     help for export-by-json
-  -o, --organization string      ID of the Cloud Foundry organization
+  -o, --org string               ID of the Cloud Foundry org
   -p, --path string              Full path to JSON file with list of resources (default "btpResources_<account-id>.json")
   -s, --subaccount string        ID of the subaccount
 ```

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,5 +1,5 @@
 # Concepts
-The Terraform Exporter for SAP BTP (btptf CLI) provides a convenience functionality to import existing subaccounts on SAP BTP into Terraform/OpenTofu configurations. The configurations delivered by the btptf CLI are:
+The Terraform Exporter for SAP BTP (btptf CLI) provides a convenience functionality to import existing subaccounts on SAP BTP into Terraform configurations. The configurations delivered by the btptf CLI are:
 
   -	Provider configuration (excluding credentials)
   -	[Import](https://developer.hashicorp.com/terraform/language/import) blocks for the resources
@@ -19,7 +19,7 @@ The btptf CLI offers two options for the import:
 
 2.	Creating the files with the import block based on the information from the documentation and reading the data from the platform leveraging the corresponding Terraform [data sources](https://registry.terraform.io/providers/SAP/btp/latest/docs).
 
-3.	Executing the Terraform/OpenTofu commands via Terraform/OpenTofu CLI to generate the resource configuration and store the results in the file system.
+3.	Executing the Terraform commands via the Terraform CLI to generate the resource configuration and store the results in the file system.
 
 The following points should be mentioned:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,15 @@
 # Terraform Exporter for SAP BTP
 
-The *Terraform Exporter for SAP BTP* (btptf CLI) is a handy tool that makes it easier to bring your existing SAP Business Technology Platform ([BTP](https://www.sap.com/products/technology-platform/what-is-sap-business-technology-platform.html)) resources into [Terraform](https://www.terraform.io/) or [OpenTofu](https://opentofu.org/).
+The *Terraform Exporter for SAP BTP* (btptf CLI) exports existing SAP BTP resources as Terraform code, so you can start adopting Infrastructure-as-Code with Terraform.
 
-With it, you can take things like subaccounts and directories in BTP and turn them into Terraform/OpenTofu state and configuration files. It is especially useful for teams who are moving to Terraform/OpenTofu but still need to manage older infrastructure or SAP BTP accounts that are already set up.
+The following SAP BTP account levels can be exported:
+
+- Directories
+- Subaccounts
+- Cloud Foundry environment instances
+
+!!! info
+    The Terraform Exporter for SAP BTP is fully compatible with [OpenTofu](https://opentofu.org/). All steps outlined in this guide can be executed using either the Terraform CLI or the OpenTofu CLI. For simplicity, this documentation will only reference [Terraform](https://www.terraform.io/).
 
 
 ## How does it work
@@ -10,5 +17,3 @@ With it, you can take things like subaccounts and directories in BTP and turn th
 - **Resource Identification**: Terraform Exporter for SAP BTP identifies the SAP BTP resources and maps them to corresponding Terraform resources using the BTP CLI Server APIs.
 - **Import Process**: The tool utilizes Terraform's [import](https://developer.hashicorp.com/terraform/cli/import) function to integrate each resource into Terraform's state.
 - **Configuration Generation**: After import, it generates the Terraform code (in HashiCorp Configuration Language - HCL) for each resource, enabling further customizations as needed.
-
-The same steps apply when using OpenTofu.

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ If you want to build the binary from scratch, follow these steps:
 
 1. Open [this](https://github.com/SAP/terraform-exporter-btp) repository inside VS Code Editor
 
-2. We have setup a [devcontainer](https://code.visualstudio.com/docs/devcontainers/tutorial), so reopen the repository in the devcontainer. We provide devcontainers for Terraform and OpenTofu.
+2. We have setup a [devcontainer](https://code.visualstudio.com/docs/devcontainers/tutorial), so reopen the repository in the devcontainer.
 
 3. Open a terminal in VS Code and install the binary by running
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -2,13 +2,13 @@
 
 ## Supported Resources for Import
 
-The btptf CLI can create import blocks and the corresponding configurations only for resources that support the import functionality of Terraform/OpenTofu. Not all resources available in the Terraform providers support this feature and can hence not be imported.
+The btptf CLI can create import blocks and the corresponding configurations only for resources that support the import functionality of Terraform. Not all resources available in the Terraform providers support this feature and can hence not be imported.
 
 You find a list of supported resources for the Terraform Provider for SAP BTP in the corresponding repository on GitHub under the [Overview on importable resources](https://github.com/SAP/terraform-provider-btp/blob/main/guides/IMPORT.md).
 
 ## Restrictions for Cloud Foundry
 
-The btptf CLI can create import blocks and the corresponding configurations only for resources that support the import functionality of Terraform/OpenTofu. Not all resources available in the Terraform providers support this feature and can hence not be imported. For details please check the [documentation](https://registry.terraform.io/providers/cloudfoundry/cloudfoundry/latest).
+The btptf CLI can create import blocks and the corresponding configurations only for resources that support the import functionality of Terraform. Not all resources available in the Terraform providers support this feature and can hence not be imported. For details please check the [documentation](https://registry.terraform.io/providers/cloudfoundry/cloudfoundry/latest).
 
 In case of resources for Cloud Foundry the btptf CLI focuses on the resources that are available in the Cloud Foundry environment on SAP BTP. It is not intended to be a generic tool for vanilla Cloud Foundry deployments.
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -2,7 +2,7 @@
 
 ## Terraform/OpenTofu CLI
 
-The btptf CLI requires a installation of the Terraform CLI or the OpenTofu CLI. The corresponding CLI will be detected and called by the btptf CLI.
+The btptf CLI requires a installation of the Terraform or the OpenTofu CLI. The corresponding CLI will be detected and called by the btptf CLI.
 
 You find the necessary information in the official documentation:
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- update of CLI help and shortcuts
- renaming of `organization` to `org` as CLI parameter to be inline with Cloud Foundry terminology
- refinement of OpenTofu usage


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Be aware that the `organization` parameter has been renamed to `org` in the CLI. This is to be inline with the Cloud Foundry terminology. The `organization` parameter is removed.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
