### PR TITLE
fix: export of role collection with comma

### DIFF
--- a/pkg/tfutils/testdata/testImportUsingIdentity.md
+++ b/pkg/tfutils/testdata/testImportUsingIdentity.md
@@ -1,0 +1,27 @@
+## Import
+
+Import is supported using the following syntax:
+
+```terraform
+# terraform import btp_subaccount_subscription.<resource_name> <subaccount_id>,<app_name>,<plan_name>
+
+terraform import btp_subaccount_subscription.workzone 6aa64c2f-38c1-49a9-b2e8-cf9fea769b7f,SAPLaunchpad,free
+
+#terraform import using id attribute in import block
+
+import {
+  to = btp_subaccount_subscription.<resource_name>
+  id = "<subaccount_id>,<app_name>,<plan_name>"
+}
+
+# this resource supports import using identity attribute from Terraform version 1.12 or higher
+
+import {
+to = btp_subaccount_subscription.<resource_name>
+identity = {
+  subaccount_id = "<subaccount_id>"
+  app_name = "<app_name>"
+  plan_name = "<plan_name>"
+  }
+}
+```

--- a/pkg/tfutils/tfDocs_test.go
+++ b/pkg/tfutils/tfDocs_test.go
@@ -21,6 +21,10 @@ func TestParseImport(t *testing.T) {
 			input:    readlines(t, "testdata/testImport.md"),
 			expected: "import {\n\t\t\t\tto = btp_subaccount.<resource_name>\n\t\t\t\tid = \"<subaccount_id>\"\n\t\t\t  }",
 		},
+		{
+			input:    readlines(t, "testdata/testImportUsingIdentity.md"),
+			expected: "import {\n\t\t\t\t\tto = btp_subaccount_subscription.<resource_name>\n\t\t\t\t\tidentity = {\n\t\t\t\t\tsubaccount_id = \"<subaccount_id>\"\napp_name = \"<app_name>\"\nplan_name = \"<plan_name>\"\n\n\t\t\t\t\t}\n\t\t\t\t  }",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tfutils/tfImport.go
+++ b/pkg/tfutils/tfImport.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Constants for TF version for Terraform providers
-const BtpProviderVersion = "v1.13.0"
+const BtpProviderVersion = "v1.14.0"
 const CfProviderVersion = "v1.7.0"
 
 const (


### PR DESCRIPTION
## Purpose
- This pull request addresses an issue where importing a BTP resource with a comma in its name would fail.
- Exporter is updated to consider using [resources-identity](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/identity) when generating import blocks, provided the resource supports import via resource identity.
- Resource identity support is conditional on the Terraform version being 1.12 or above. The exporter now checks the Terraform version and creates the import block accordingly.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR status on the Project board is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up issues are created and linked.
