### PR TITLE
fix: adjust filtering of default roles

### DIFF
--- a/internal/btpcli/wrapper.go
+++ b/internal/btpcli/wrapper.go
@@ -137,8 +137,8 @@ func GetDefaultRolesBySubaccount(subaccountId string, client *ClientFacade) (def
 	}
 
 	for _, role := range cliRes {
-		// The roles that are marked as IsReadOnly and contain an empty attribute list are predefined and need not be exported
-		if role.IsReadOnly && len(role.AttributeList) == 0 {
+		// The roles that are marked as IsReadOnly or are not read only but contain a non-empty attribute list are predefined and need not be exported
+		if role.IsReadOnly || (!role.IsReadOnly && len(role.AttributeList) > 0) {
 			roles = append(roles, role.Name)
 		}
 	}
@@ -155,8 +155,8 @@ func GetDefaultRolesByDirectory(directoryId string, client *ClientFacade) (defau
 	}
 
 	for _, role := range cliRes {
-		// The roles that are marked as IsReadOnly and contain an empty attribute list are predefined and need not be exported
-		if role.IsReadOnly && len(role.AttributeList) == 0 {
+		// The roles that are marked as IsReadOnly or are not read only but contain a non-empty attribute list are predefined and need not be exported
+		if role.IsReadOnly || (!role.IsReadOnly && len(role.AttributeList) > 0) {
 			roles = append(roles, role.Name)
 		}
 	}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Adjust filtering of default roles to exclude roles that:
  - are read-only
  - are not read only but have a customizing attached


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
