### PR TITLE
fix: format of security setting templating

### DIFF
--- a/pkg/tfimportprovider/subaccountSecuritySettingImportProvider.go
+++ b/pkg/tfimportprovider/subaccountSecuritySettingImportProvider.go
@@ -52,7 +52,7 @@ func createSecuritySettingImportBlock(data map[string]any, subaccountId string, 
 	}
 
 	template := strings.ReplaceAll(resourceDoc.Import, "<resource_name>", "secsetting")
-	template = strings.ReplaceAll(template, "'<subaccount_id>'", subaccountId)
+	template = strings.ReplaceAll(template, "<subaccount_id>", subaccountId)
 	importBlock += template + "\n"
 
 	return importBlock, nil

--- a/pkg/tfimportprovider/subaccountSecuritySettingImportProvider_test.go
+++ b/pkg/tfimportprovider/subaccountSecuritySettingImportProvider_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCreateSecuritySettingImportBlock(t *testing.T) {
 	resourceDoc := tfutils.EntityDocs{
-		Import: "import {\n\t\t\t\tto = btp_subaccount_security_settings.<resource_name>\n\t\t\t\tid = \"'<subaccount_id>'\"\"\n\t\t\t  }\n",
+		Import: "import {\n\t\t\t\tto = btp_subaccount_security_settings.<resource_name>\n\t\t\t\tid = \"<subaccount_id>\"\"\n\t\t\t  }\n",
 	}
 
 	jsonString := "{\"access_token_validity\": -1,\"custom_email_domains\": [],\"default_identity_provider\":\"sap.default\",\"iframe_domains\":\"\",\"refresh_token_validity\": -1,\"subaccount_id\":\"12345\",\"treat_users_with_same_email_as_same_user\": false}"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fix templating of security settings import block by removing extra single quotes around subaccount_id.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
