### PR TITLE
fix: strip colors from Terraform command executions

### DIFF
--- a/pkg/tfutils/tfWrapper.go
+++ b/pkg/tfutils/tfWrapper.go
@@ -46,6 +46,7 @@ func runTfCmdGeneric(args ...string) (errorStream string, err error) {
 	}
 
 	verbose := viper.GetViper().GetBool("verbose")
+	args = append(args, "-no-color")
 	cmd := exec.Command(tool, args...)
 	var stderr bytes.Buffer
 
@@ -57,7 +58,6 @@ func runTfCmdGeneric(args ...string) (errorStream string, err error) {
 		cmd.Stderr = &stderr
 	}
 
-	// cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Strip colors from internal Terraform command executions

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
